### PR TITLE
Cache quickMinMax for images.

### DIFF
--- a/xicam/NCEM/widgets/FFTViewerPlugin.py
+++ b/xicam/NCEM/widgets/FFTViewerPlugin.py
@@ -6,7 +6,7 @@ from qtpy.QtWidgets import *
 from xicam.plugins import QWidgetPlugin
 from xicam.core import msg
 from .NCEMViewerPlugin import NCEMViewerPlugin
-from .ncemimageview import NCEMImageView
+from .ncemimageview import NCEMFFTView
 
 
 class FFTViewerPlugin(QWidgetPlugin):
@@ -20,7 +20,7 @@ class FFTViewerPlugin(QWidgetPlugin):
 
         # Two NCEM image views
         self.Rimageview = NCEMViewerPlugin(catalog)
-        self.Fimageview = NCEMImageView()
+        self.Fimageview = NCEMFFTView()
 
         # Keep Y-axis as is
         self.Rimageview.view.invertY(True)
@@ -99,7 +99,8 @@ class FFTViewerPlugin(QWidgetPlugin):
             dataSlice = data[int(y / scale0[1]):int((y + h) / scale0[1]), int(x / scale0[0]):int((x + w) / scale0[0])]
 
             fft = np.fft.fft2(dataSlice)
-            self.Fimageview.setImage(np.log(np.abs(np.fft.fftshift(fft)) + 1))  # , autoLevels = self.autoLevels)
+            self.Fimageview.setImage(np.log(np.abs(np.fft.fftshift(fft)) + 1)) #, autoLevels = self.autoLevels)
+
             self.autoLevels = False
             self.Rroi.setPen(pg.mkPen('w'))
         except ValueError:

--- a/xicam/NCEM/widgets/ncemimageview.py
+++ b/xicam/NCEM/widgets/ncemimageview.py
@@ -1,4 +1,4 @@
-
+import functools
 import numpy as np
 
 from xicam.gui.widgets.dynimageview import DynImageView
@@ -7,6 +7,26 @@ from xicam.gui.widgets.dynimageview import DynImageView
 class NCEMImageView(DynImageView):
     def __init__(self, *args, **kwargs):
         super(NCEMImageView, self).__init__(*args, **kwargs)
+
+    @functools.lru_cache(maxsize=10, typed=False)
+    def quickMinMax(self, data):
+        """
+        Estimate the min/max values of *data* by subsampling.
+        Removes 0.1% on the top and bottom for TEM data.
+        """
+        if data is None:
+            return 0, 0
+        ax = np.argmax(data.shape)
+        sl = [slice(None)] * data.ndim
+        sl[ax] = slice(None, None, max(1, int(data.size // 1e6)))
+        data = data[tuple(sl)]
+        return (np.nanpercentile(np.where(data > np.nanmin(data), data, np.nanmax(data)), .1),
+                np.nanpercentile(np.where(data < np.nanmax(data), data, np.nanmin(data)), 99.9))
+
+
+class NCEMFFTView(DynImageView):
+    def __init__(self, *args, **kwargs):
+        super(NCEMFFTView, self).__init__(*args, **kwargs)
 
     def quickMinMax(self, data):
         """
@@ -18,6 +38,6 @@ class NCEMImageView(DynImageView):
         ax = np.argmax(data.shape)
         sl = [slice(None)] * data.ndim
         sl[ax] = slice(None, None, max(1, int(data.size // 1e6)))
-        data = data[sl]
-        return (np.nanpercentile(np.where(data > np.nanmin(data), data, np.nanmax(data)), .1),
-                np.nanpercentile(np.where(data < np.nanmax(data), data, np.nanmin(data)), 99.1))
+        data = data[tuple(sl)]
+        return (np.nanpercentile(np.where(data > np.nanmin(data), data, np.nanmax(data)), .5),
+                np.nanpercentile(np.where(data < np.nanmax(data), data, np.nanmin(data)), 99.9))


### PR DESCRIPTION
Add NCEMFFTView to change behavior of how FFTs are displayed compared to real space images

Update the NCEMImageView quickMinMax to use 0.1% and 99.9%. Previously had a typo for 99.1%